### PR TITLE
[Create Video] Add API to create video in DB

### DIFF
--- a/createVideo.js
+++ b/createVideo.js
@@ -1,0 +1,48 @@
+import Sequelize from 'sequelize';
+import Video from './db/models/video';
+import db from './config/db';
+
+export async function main(event, context, callback) {
+  // Do not wait for sequelize connection to close
+  context.callbackWaitsForEmptyEventLoop = false;
+
+  const headers = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Credentials': true,
+  };
+
+  Video.init(db);
+
+  let response;
+  let statusCode;
+
+  const { name, owner, location } = JSON.parse(event.body);
+  const videoData = { name, owner, location };
+
+  try {
+    const createdVideo = await Video.create(videoData);
+    statusCode = 201;
+
+    response = {
+      statusCode,
+      headers,
+      body: JSON.stringify(createdVideo),
+    };
+  } catch (error) {
+    statusCode = 500;
+    let { message } = error;
+
+    if (error instanceof Sequelize.ForeignKeyConstraintError) {
+      statusCode = 400;
+      message = 'Video owner does not exist';
+    }
+
+    response = {
+      statusCode,
+      headers,
+      body: JSON.stringify({ message }),
+    };
+  }
+
+  callback(null, response);
+}

--- a/db/models/video.js
+++ b/db/models/video.js
@@ -1,12 +1,24 @@
-'use strict';
-module.exports = (sequelize, DataTypes) => {
-  const Video = sequelize.define('Video', {
-    name: DataTypes.STRING,
-    owner: DataTypes.INTEGER,
-    location: DataTypes.STRING
-  }, {});
-  Video.associate = function(models) {
-    Video.belongsTo(models.User);
-  };
-  return Video;
-};
+import { Model, DataTypes } from 'sequelize';
+
+class Video extends Model {
+  static associate(models) {
+    this.userAssociation = models.Video.belongsTo(models.User);
+  }
+
+  static init(sequelize) {
+    return super.init({
+      name: DataTypes.STRING,
+      owner: DataTypes.INTEGER,
+      location: {
+        allowNull: false,
+        type: DataTypes.STRING,
+      },
+    },
+    {
+      sequelize,
+      tableName: 'Videos',
+    });
+  }
+}
+
+export default Video;

--- a/serverless.yml
+++ b/serverless.yml
@@ -29,6 +29,13 @@ functions:
           path: users
           method: post
           cors: true
+  createVideo:
+    handler: createVideo.main
+    events:
+      - http:
+          path: videos
+          method: post
+          cors: true
 
 plugins:
   - serverless-webpack


### PR DESCRIPTION
## Description

- Adds the `createVideo` API , with path `/videos` and `POST` method,
  which allows users to create an entry in the database for a new
  video, with name, location (S3 URL) and associated to the user through
  their ID
- Updates the `Video` model to use ES6 classes.

## Testing

 - Tested by creating a mock request
  ```
// mocks/create-video.json

{
  "body": "{\"name\": \"test video\",\"owner\": 1, \"location\": \"mocklocation\"}",
  "requestContext": {
    "identity": {
      "cognitoIdentityId": "USER-SUB-1234"
    }
  }
}
  ```
  And using
```
serverless invoke local --function createVideo --path mocks/create-video.json
```
And verifying that the video is created in the database and also that trying to create the video with an invalid `owner` ID again results in a validation error because of the foreign key constraint in the database.


Also tested by deploying the function and using `aws-api-gateway-cli-test` and verifying the same conditions as the previous test.