### PR TITLE
[videoAPI] Adds API for getVideo and listVideo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ jspm_packages
 mocks/
 secrets.json
 
+# Mac specifc
+.DS_Store

--- a/getVideo.js
+++ b/getVideo.js
@@ -1,0 +1,47 @@
+import Sequelize from 'sequelize';
+import Video from './db/models/video';
+import db from './config/db';
+
+export async function main(event, context, callback) {
+  // Do not wait for sequelize connection to close
+  context.callbackWaitsForEmptyEventLoop = false;
+
+  const headers = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Credentials': true,
+  };
+
+  Video.init(db);
+
+  let response;
+  let statusCode;
+
+  const id = event.pathParameters.id;
+
+  try {
+    const result = await Video.findByPk(id);
+    statusCode = 200;
+    let body = JSON.stringify(result);
+
+    if (result === null) {
+      statusCode = 404;
+      body = JSON.stringify({ message: 'Empty query result' });
+    }
+
+    response = {
+      statusCode,
+      headers,
+      body,
+    };
+  } catch (error) {
+    statusCode = 500;
+
+    response = {
+      statusCode,
+      headers,
+      body: JSON.stringify(error),
+    };
+  }
+
+  callback(null, response);
+}

--- a/listVideo.js
+++ b/listVideo.js
@@ -1,0 +1,39 @@
+import Sequelize from 'sequelize';
+import Video from './db/models/video';
+import db from './config/db';
+
+export async function main(event, context, callback) {
+  // Do not wait for sequelize connection to close
+  context.callbackWaitsForEmptyEventLoop = false;
+
+  const headers = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Credentials': true,
+  };
+
+  Video.init(db);
+
+  let response;
+  let statusCode;
+
+  try {
+    const result = await Video.findAll();
+    statusCode = 200;
+
+    response = {
+      statusCode,
+      headers,
+      body: JSON.stringify(result),
+    };
+  } catch (error) {
+    statusCode = 500;
+
+    response = {
+      statusCode,
+      headers,
+      body: JSON.stringify(error),
+    };
+  }
+
+  callback(null, response);
+}

--- a/serverless.yml
+++ b/serverless.yml
@@ -25,7 +25,7 @@ functions:
   createUser:
     handler: createUser.main
     events:
-      - http: 
+      - http:
           path: users
           method: post
           cors: true
@@ -36,6 +36,24 @@ functions:
           path: videos
           method: post
           cors: true
+  listVideo:
+    handler: listVideo.main
+    events:
+      - http:
+          path: videos
+          method: get
+          cors: true
+  getVideo:
+    handler: getVideo.main
+    events:
+      - http:
+          path: videos/{id}
+          method: get
+          cors: true
+          request:
+            parameters:
+              paths:
+                id: true
 
 plugins:
   - serverless-webpack


### PR DESCRIPTION
# Description
- Adds the getVideo API, with path videos/{id} and GET method. Allows users to query for a row of the Videos table in the database
- Adds the listVideo API, with path videos and GET method. Allows users to query for all rows of the Videos table in the database
- Updates the .gitignore to include mac specific files

## Testing
### getVideo
```
// mocks/get-video.json

{
  "pathParameters": {"id": 2}
}
```
cmd:
```$ serverless invoke local --function getVideo --path mocks/get-video.json```

or:
```
// mocks/get-video.sh
...
```
cmd:
```$ sh mocks/get-video.sh```

Returns the video row with the corresponding id from the query

### listVideo
cmd:
```$ serverless invoke local --function listVideo```

or:
```
// mocks/list-video.sh
...
```
cmd:
```sh mocks/list-video.sh```

Returns all rows from the Videos table