### PR TITLE
[User API] Add API for listUser and getUser

### DIFF
--- a/getUser.js
+++ b/getUser.js
@@ -1,0 +1,47 @@
+import Sequelize from 'sequelize';
+import User from './db/models/user';
+import db from './config/db';
+
+export async function main(event, context, callback) {
+  // Do not wait for sequelize connection to close
+  context.callbackWaitsForEmptyEventLoop = false;
+
+  const headers = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Credentials': true,
+  };
+
+  User.init(db);
+
+  let response;
+  let statusCode;
+
+  const id = event.pathParameters.id;
+
+  try {
+    const result = await User.findByPk(id);
+    statusCode = 200;
+    let body = JSON.stringify(result);
+
+    if (result === null) {
+      statusCode = 404;
+      body = JSON.stringify({ message: 'Empty query result' });
+    }
+
+    response = {
+      statusCode,
+      headers,
+      body,
+    };
+  } catch (error) {
+    statusCode = 500;
+
+    response = {
+      statusCode,
+      headers,
+      body: JSON.stringify(error),
+    };
+  }
+
+  callback(null, response);
+}

--- a/listUser.js
+++ b/listUser.js
@@ -1,0 +1,39 @@
+import Sequelize from 'sequelize';
+import User from './db/models/user';
+import db from './config/db';
+
+export async function main(event, context, callback) {
+  // Do not wait for sequelize connection to close
+  context.callbackWaitsForEmptyEventLoop = false;
+
+  const headers = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Credentials': true,
+  };
+
+  User.init(db);
+
+  let response;
+  let statusCode;
+
+  try {
+    const result = await User.findAll();
+    statusCode = 200;
+
+    response = {
+      statusCode,
+      headers,
+      body: JSON.stringify(result),
+    };
+  } catch (error) {
+    statusCode = 500;
+
+    response = {
+      statusCode,
+      headers,
+      body: JSON.stringify(error),
+    };
+  }
+
+  callback(null, response);
+}

--- a/serverless.yml
+++ b/serverless.yml
@@ -29,6 +29,24 @@ functions:
           path: users
           method: post
           cors: true
+  listUser:
+    handler: listUser.main
+    events:
+      - http:
+          path: users
+          method: get
+          cors: true
+  getUser:
+    handler: getUser.main
+    events:
+      - http:
+          path: users/{id}
+          method: get
+          cors: true
+          request:
+            parameters:
+              paths:
+                id: true
   createVideo:
     handler: createVideo.main
     events:


### PR DESCRIPTION
# Description
Adds the listUser API, with path users and GET method. Allows users to query for all rows of the Users table in the database
Adds the getUser API, with path users/{id} and GET method. Allows users to query for a row of the Users table in the database

## Testing
### listUser
cmd:
```
$ serverless invoke local --function listUser
```

or:
```
$ sh mocks/list-user.sh
```
Returns all rows from the Users table

### getUser
```
// mocks/get-user.json
{
  "pathParameters": { "id": 35 }
}
```
cmd:
```
$ serverless invoke local --function listUser -- path mocks/get-user.json
```

or:
```
$ sh mocks/get-user.sh
```
Returns the user row with the corresponding id from the query