### PR TITLE
[MultiRes] Resize video to different resolutions

### DIFF
--- a/functions/processing/createStrip.js
+++ b/functions/processing/createStrip.js
@@ -1,18 +1,10 @@
-import fs, {
-  readFileSync,
-  writeFileSync,
-} from 'fs';
+import { readFileSync, writeFileSync } from 'fs';
 import ffmpeg from 'fluent-ffmpeg';
 import im from 'imagemagick';
 import { S3 } from 'aws-sdk';
+import { asyncForEach } from './utils';
 
 const s3 = new S3();
-
-async function asyncForEach(array, callback) {
-  for (let index = 0; index < array.length; index++) {
-    await callback(array[index], index, array);
-  }
-}
 
 async function uploadToS3(imageFileName, bucketName) {
   try {
@@ -64,7 +56,7 @@ export function main(event) {
       Key: key,
     }).promise();
 
-    const videoName = key.split('/')[2].split('.')[0];
+    const videoName = key.split('/')[2].split('.')[0].split('_')[1];
     const filename = `/tmp/${videoName}.mp4`;
     writeFileSync(filename, s3Object.Body);
 

--- a/functions/processing/multiRes.js
+++ b/functions/processing/multiRes.js
@@ -1,0 +1,93 @@
+import { readFileSync, writeFileSync } from 'fs';
+import ffmpeg from 'fluent-ffmpeg';
+import { S3 } from 'aws-sdk';
+import { asyncForEach } from './utils';
+
+const s3 = new S3();
+
+const resolutions = [
+  { height: 1080, width: 1920 },
+  { height: 720, width: 1280 },
+  { height: 540, width: 960 },
+  { height: 360, width: 640 },
+  { height: 144, width: 256 },
+];
+
+async function uploadToS3(filename, bucketName) {
+  try {
+    const file = readFileSync(`/tmp/${filename}`);
+    console.log(`${filename} - starting upload.`);
+
+    await s3.putObject({
+      Body: file,
+      Bucket: bucketName,
+      Key: `public/outputs/${filename}`,
+    }).promise();
+
+    console.log(`${filename} - uploaded.`);
+  } catch (error) {
+    console.log(`Error uploading ${filename}\n${error}`);
+  }
+}
+
+async function resizeAndUpload(videoName, { height, width }, bucketName) {
+  const filename = `/tmp/${videoName}.mp4`;
+  const resFilename = `${height}_${videoName}.mp4`;
+  const res = `${width}x${height}`;
+
+  ffmpeg(filename)
+    .videoCodec('libx264')
+    .size(res)
+    .save(`/tmp/${resFilename}`)
+    .on('start', () => console.log(`Resizing to ${res}`))
+    .on('end', () => {
+      console.log(`Created resized ${resFilename}`);
+      uploadToS3(resFilename, bucketName);
+    });
+}
+
+function processVideo(videoName, bucketName) {
+  const filename = `/tmp/${videoName}.mp4`;
+  ffmpeg.ffprobe(filename, async (err, { streams: [videoMetadata, ...rest] }) => {
+    const videoHeight = videoMetadata.height;
+
+    console.log(`Got video height: ${videoHeight}`);
+
+    const promises = resolutions.map(async (res) => {
+      if (videoHeight >= res.height) {
+        resizeAndUpload(videoName, res, bucketName);
+      }
+    })
+
+    await Promise.all(promises);
+  });
+}
+
+export function main(event) {
+  // Sanity checks
+  if (!event.Records) {
+    console.log('Not an invocation. Aborting...');
+    return;
+  }
+
+  asyncForEach(event.Records, async (record) => {
+    if (!record.s3) {
+      console.log('Not an S3 event. Aborting...')
+      return;
+    }
+
+    const { key } = record.s3.object;
+    const bucketName = record.s3.bucket.name;
+
+    const s3Object = await s3.getObject({
+      Bucket: bucketName,
+      Key: key,
+    }).promise();
+
+    const videoName = key.split('/')[2].split('.')[0];
+    const filename = `/tmp/${videoName}.mp4`;
+    writeFileSync(filename, s3Object.Body);
+
+    processVideo(videoName, bucketName);
+  });
+}

--- a/functions/processing/utils.js
+++ b/functions/processing/utils.js
@@ -1,0 +1,5 @@
+export async function asyncForEach(array, callback) {
+  for (let index = 0; index < array.length; index++) {
+    await callback(array[index], index, array);
+  }
+}

--- a/resources/functions.yml
+++ b/resources/functions.yml
@@ -97,4 +97,15 @@ createStrip:
         events:
           - 's3:ObjectCreated:*'
         rules:
+          - prefix: 'public/outputs/144_'
+multiRes:
+  handler: functions/processing/multiRes.main
+  layers:
+    - arn:aws:lambda:eu-central-1:861288909389:layer:ffmpeg:1
+  events:
+    - existingS3:
+        bucket: 'videocloud-production-inputbucket-1p5ppjlf78zwe'
+        events:
+          - 's3:ObjectCreated:*'
+        rules:
           - prefix: 'public/videos/'


### PR DESCRIPTION
## Description

When a user uploads a video, it triggers the `multiRes` function, which
will create resized copies of the video in 1080p, 720p, 540p, 360p and
144p, starting with the highest resolution that is equal or smaller than
the video's native resolution.

The resulting videos are uploaded to S3, in the `public/outputs/` folder
of the input bucket.

Also changes the strip creation function so that it uses the 144p
version of the video to create the strip.

## Testing

Manually tested by copy-pasting a file that was already on S3, and verifying that the resized versions were created, as well as the strip.